### PR TITLE
Nil check to fix the failed tests in issue #25

### DIFF
--- a/lib/piggly/dumper/reified_procedure.rb
+++ b/lib/piggly/dumper/reified_procedure.rb
@@ -63,7 +63,8 @@ module Piggly
       end
 
       def defaults(exprs, count, total)
-        exprs = exprs.split(", ")
+        exprs = if exprs.nil? then [] else exprs.split(", ") end
+
         nreqd = total - count
 
         if nreqd >= 0 and exprs.length == count


### PR DESCRIPTION
#25 was caused by not checking for nil when splitting exprs. This adds in a nil check on exprs.