### PR TITLE
Extend the grammer to explicitly support CURSOR variables in a declaration section.

### DIFF
--- a/example/proc/declare_cursor.sql
+++ b/example/proc/declare_cursor.sql
@@ -1,0 +1,14 @@
+create or replace function foo()
+returns void
+language plpgsql
+as $$
+DECLARE
+   gencur refcursor;
+   mycur CURSOR FOR SELECT * from pg_database;
+   mycur2 SCROLL CURSOR FOR SELECT * from pg_database;
+   mycur3 NO SCROLL CURSOR FOR SELECT * from pg_database;
+   mycur4 CURSOR (key integer) FOR SELECT * from pg_database where encoding = key;
+BEGIN
+   return;
+END;
+$$;

--- a/example/proc/snippets.sql
+++ b/example/proc/snippets.sql
@@ -2,6 +2,7 @@ CREATE OR REPLACE FUNCTION snippets(a integer, b boolean) RETURNS SETOF pg_names
 DECLARE
   x               varchar(20);
   n               integer := 403;
+  m               integer DEFAULT 404;
   i               integer;
   ys              integer[] := '{}';
   result          text;
@@ -11,6 +12,7 @@ DECLARE
   myself          pg_proc%ROWTYPE;
   shareCount      integer := 99999999;
   count           integer;
+  local_a         text COLLATE "en_US";
 BEGIN
 
   -- IF-THEN

--- a/lib/piggly/parser/grammar.tt
+++ b/lib/piggly/parser/grammar.tt
@@ -271,9 +271,21 @@ grammar Piggly
   end
 
   rule varDeclaration
+    varDeclarationMisc / varDeclarationCursor
+  end
+
+  rule varDeclarationMisc
     name:tIdentifier tSpace ( kwCONSTANT tSpace )?
-    type:tType ( tSpace  kwNOT tSpace kwNULL )?
-               ( tSpace? kwASSIGN tSpace? rval:expressionUntilSemiColon )?
+    type:tType ( tSpace  kwCOLLATE name:tIdentifier )?
+               ( tSpace  kwNOT tSpace kwNULL )?
+               ( tSpace? ( kwASSIGN / kwDEFAULT ) tSpace? rval:expressionUntilSemiColon )?
+    tSpace?
+    ';' tSpace?
+  end
+
+  rule varDeclarationCursor
+    name:tIdentifier tSpace ( ( kwNO tSpace )? kwSCROLL tSpace )? kwCURSOR tSpace
+      rval:expressionUntilSemiColon
     tSpace?
     ';' tSpace?
   end
@@ -494,7 +506,7 @@ grammar Piggly
     #   EXIT WHEN cond;
 
     kwWHEN / kwAS / kwASSIGN / kwALIAS / kwBEGIN / kwBY / kwCASE / kwARRAY
-    / kwCONSTANT / kwCONTINUE / kwCURSOR / kwDEBUG / kwDECLARE / kwDEFAULT
+    / kwCOLLATE / kwCONSTANT / kwCONTINUE / kwCURSOR / kwDEBUG / kwDECLARE / kwDEFAULT
     / kwDIAGNOSTICS / kwELSE / kwELSIF / kwEND / kwEXCEPTION / kwEXECUTE / kwEXIT
     / kwFOR / kwFROM / kwGET / kwIF / kwIN / kwINFO / kwINSERT / kwINTO
     / kwIS / kwLOG / kwLOOP / kwNOT / kwNOTICE / kwNULL / kwFOREACH
@@ -534,6 +546,10 @@ grammar Piggly
 
   rule kwCASE
     'case' ![a-z0-9_] <Piggly::Parser::Nodes::TKeyword>
+  end
+
+  rule kwCOLLATE
+    'collate' ![a-z0-9_] <Piggly::Parser::Nodes::TKeyword>
   end
 
   rule kwCONSTANT
@@ -638,6 +654,10 @@ grammar Piggly
 
   rule kwNEXT
     'next' ![a-z0-9_] <Piggly::Parser::Nodes::TKeyword>
+  end
+
+  rule kwNO
+    'no' ![a-z0-9_] <Piggly::Parser::Nodes::TKeyword>
   end
 
   rule kwNOT


### PR DESCRIPTION
To fix issue #45.

Also allow "COLLATE" and "DEFAULT" in regular variable declarations.